### PR TITLE
Implement sticky sidebar support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,11 @@ The following themes exist:
 **kr_small**
 	small one-page theme.  Intended to be used by very small addon libraries.
 
+
+Theme Options
+---------------
+
+kr
++++
+
+- **stickysidebar** (true or false): Make the sidebar "fixed" so that it doesn't scroll out of view for long body content. Defaults to false.

--- a/kr/static/flasky.css_t
+++ b/kr/static/flasky.css_t
@@ -38,6 +38,15 @@ div.bodywrapper {
 
 div.sphinxsidebar {
     width: {{ sidebar_width }};
+
+    {%- if theme_stickysidebar|tobool %}
+    top: 30px;
+    bottom: 0;
+    margin: 0;
+    position: fixed;
+    overflow: auto;
+    height: auto;
+    {%- endif %}
 }
 
 hr {

--- a/kr/theme.conf
+++ b/kr/theme.conf
@@ -5,3 +5,4 @@ pygments_style = flask_theme_support.FlaskyStyle
 
 [options]
 touch_icon = 
+stickysidebar = false


### PR DESCRIPTION
It would be nice to have a sticky sidebar when displaying some long text.

This implementation is derived from sphinx's [default theme](https://bitbucket.org/birkenfeld/sphinx/src/b6065ae5d7c055e07686c74e789a00589d20a320/sphinx/themes/default/static/default.css_t?at=default#cl-74), it just works.
